### PR TITLE
Convert dir to csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ pip install xlsx2csv
   -m, --merge-cells     merge cells
 ```
 
+Usage with folder containing multiple `xlxs` files:
+```
+    python xlsx2csv.py /path/to/input/dir /path/to/output/dir
+```
+will output each file in the input dir converted to `.csv` in the output dir. If omitting the output dir it will output the converted files in the input dir
+
 Usage from within Python:
 ```
   from xlsx2csv import Xlsx2csv

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -1023,7 +1023,9 @@ def convert_recursive(path, sheetid, outfile, kwargs):
             convert_recursive(fullpath, sheetid, outfile, kwargs)
         else:
             outfilepath = outfile
-            if os.path.isdir(outfilepath):
+            if isinstance(outfilepath, type(sys.stdout)):
+                outfilepath = fullpath[:-4] + 'csv'
+            elif os.path.isdir(outfilepath):
                 outfilepath = os.path.join(outfilepath, name[:-4] + 'csv')
             elif len(outfilepath) == 0 and fullpath.lower().endswith(".xlsx"):
                 outfilepath = fullpath[:-4] + 'csv'

--- a/xlsx2csv.py
+++ b/xlsx2csv.py
@@ -1023,7 +1023,9 @@ def convert_recursive(path, sheetid, outfile, kwargs):
             convert_recursive(fullpath, sheetid, outfile, kwargs)
         else:
             outfilepath = outfile
-            if len(outfilepath) == 0 and fullpath.lower().endswith(".xlsx"):
+            if os.path.isdir(outfilepath):
+                outfilepath = os.path.join(outfilepath, name[:-4] + 'csv')
+            elif len(outfilepath) == 0 and fullpath.lower().endswith(".xlsx"):
                 outfilepath = fullpath[:-4] + 'csv'
 
             print("Converting %s to %s" % (fullpath, outfilepath))


### PR DESCRIPTION
When running the tool with a directory as input it required a single output file path, which is redundant for a directory containing multiple input files. 

These changes ensure that either the output can be discarded and then the output will be written to the input directory with each input file ending changed to `.csv` (1), or you can provide an output directory (2).

(1) can be tested by
```
python xlsx2csv.py /path/to/input/dir
```
where the input dir contains some `.xlsx` files, then the converted `.csv` files will be added to the same dir

(2) can be tested by
```
python xlsx2csv.py /path/to/input/dir /path/to/output/dir
```
where the input dir contains some `.xlsx` files, then the converted `.csv` files will be added to the output dir
